### PR TITLE
Add xarray to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     long_description="",
     license="Apache License 2.0",
     tests_require=["pytest"],
-    install_requires=["numpy"],
+    install_requires=["numpy", "xarray"],
     packages=find_packages(),
     zip_safe=False,
     rust_extensions=[RustExtension("datacube_compute.backend")],


### PR DESCRIPTION
Used in `datacube_compute/__init__.py`

Was getting this error at https://github.com/conda-forge/staged-recipes/pull/28143:

```python-traceback
Traceback (most recent call last):
  File "$SRC_DIR/conda_build_script.py", line 1, in <module>
    import datacube_compute
  File "$PREFIX/lib/python3.9/site-packages/datacube_compute/__init__.py", line 5, in <module>
    import xarray as xr
ModuleNotFoundError: No module named 'xarray'
```